### PR TITLE
Values of url params are now in array format

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -122,7 +122,9 @@ function parseQueryString() {
     });
     qMap[keyValuePair[0]] = isUndefinedOrNull(qMap[keyValuePair[0]]) ?
           keyValuePair[1] :
-          [ keyValuePair[1], ...qMap[keyValuePair[0]] ];
+          Array.isArray(qMap[keyValuePair[0]]) ?
+          [ keyValuePair[1], ...qMap[keyValuePair[0]] ] :
+          [ keyValuePair[1], qMap[keyValuePair[0]] ]
   });
 
   const handles = {

--- a/src/index.js
+++ b/src/index.js
@@ -21,10 +21,10 @@ function constructUrl(queryParams) {
 
   const keysList = Object.keys(keyValueMap);
   keysList.forEach(key => {
-    url += `${delimiter}${encodeURIComponent(key)}=${encodeURIComponent(
-      keyValueMap[key]
-    )}`;
-    delimiter = '&';
+    keyValueMap[key].forEach(val => {
+      url += `${delimiter}${encodeURIComponent(key)}=${encodeURIComponent(val)}`;
+      delimiter = '&';
+    });
   });
 
   return url;

--- a/src/index.js
+++ b/src/index.js
@@ -6,7 +6,18 @@ function constructUrl(queryParams) {
   let url = '',
     delimiter = '';
 
-  const keyValueMap = isUndefinedOrNull(queryParams) ? this.qMap : queryParams;
+  let keyValueMap;
+  if (isUndefinedOrNull(queryParams)) {
+    keyValueMap = this.qMap;
+  }
+  else {
+    keyValueMap = queryParams;
+    Object.keys(keyValueMap).forEach(key => {
+      if (!Array.isArray(keyValueMap[key]))
+        keyValueMap[key] = [ keyValueMap[key] ];
+    });
+  }
+
   if (isUndefinedOrNull(keyValueMap)) {    
     return '';
   }
@@ -39,7 +50,9 @@ function add(key, value) {
 
   const handles = {
     add: (key, value) => {
-      context.qMap[key] = value;
+      context.qMap[key] = isUndefinedOrNull(context.qMap[key]) ?
+            [ value ]:
+            [ value, ...context.qMap[key] ];
       return handles;
     },
     construct: constructUrl.bind(context)
@@ -108,7 +121,7 @@ function parseQueryString() {
         return decodeURIComponent(val);
     });
     qMap[keyValuePair[0]] = isUndefinedOrNull(qMap[keyValuePair[0]]) ?
-          [ keyValuePair[1] ] :
+          keyValuePair[1] :
           [ keyValuePair[1], ...qMap[keyValuePair[0]] ];
   });
 

--- a/src/index.js
+++ b/src/index.js
@@ -104,10 +104,12 @@ function parseQueryString() {
 
   const { qMap } = context;
   queries.forEach(query => {
-    const keyValuePair = query.split('=');
-    qMap[decodeURIComponent(keyValuePair[0])] = decodeURIComponent(
-      keyValuePair[1]
-    );
+    const keyValuePair = query.split('=').map(val => {
+        return decodeURIComponent(val);
+    });
+    qMap[keyValuePair[0]] = isUndefinedOrNull(qMap[keyValuePair[0]]) ?
+          [ keyValuePair[1] ] :
+          [ keyValuePair[1], ...qMap[keyValuePair[0]] ];
   });
 
   const handles = {


### PR DESCRIPTION
Addressed #1 

Every time a duplicate key is found, the value of the duplicate will be added to the start of the array. This is done so that users can do
```javascript
qps.parse(url).params().get(key)[0]
```
for the value that would normally be returned.